### PR TITLE
:hammer: [fix] #58 - 내외부 Controller 분리 및 낙관적 락 로직 수정

### DIFF
--- a/src/main/java/profect/group1/goormdotcom/stock/controller/external/v1/StockController.java
+++ b/src/main/java/profect/group1/goormdotcom/stock/controller/external/v1/StockController.java
@@ -1,5 +1,6 @@
 package profect.group1.goormdotcom.stock.controller.external.v1;
 
+import org.springframework.transaction.UnexpectedRollbackException;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -7,29 +8,18 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import profect.group1.goormdotcom.stock.controller.external.v1.dto.StockResponseDto;
-import profect.group1.goormdotcom.stock.controller.internal.v1.dto.ProductStockAdjustmentRequestDto;
-import profect.group1.goormdotcom.stock.controller.internal.v1.dto.StockAdjustmentRequestDto;
-import profect.group1.goormdotcom.stock.controller.internal.v1.dto.StockAdjustmentResponseDto;
 import profect.group1.goormdotcom.stock.controller.external.v1.dto.StockRequestDto;
 import profect.group1.goormdotcom.stock.controller.mapper.StockDtoMapper;
 import profect.group1.goormdotcom.stock.domain.Stock;
-import profect.group1.goormdotcom.stock.domain.exception.InsufficientStockException;
 import profect.group1.goormdotcom.stock.service.StockService;
 import profect.group1.goormdotcom.apiPayload.ApiResponse;
-import profect.group1.goormdotcom.apiPayload.code.status.ErrorStatus;
 import profect.group1.goormdotcom.apiPayload.code.status.SuccessStatus;
-
-import java.util.Map;
-import java.util.ArrayList;
-import java.util.HashMap;
 
 import java.util.UUID;
 
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.hibernate.StaleObjectStateException;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -81,77 +71,5 @@ public class StockController implements StockApiDocs {
         stockService.deleteStock(productId);
         return ApiResponse.of(SuccessStatus._OK, productId);
     }
-    
-    @PostMapping("/decrease")
-    public ApiResponse<StockAdjustmentResponseDto> decreaseStocks(
-        @RequestBody @Valid StockAdjustmentRequestDto stockAdjustmentRequestDto
-    ) {
-        Map<UUID, Integer> requestedQuantityMap = new HashMap<UUID, Integer>();
-        for (ProductStockAdjustmentRequestDto dto : stockAdjustmentRequestDto.products()) {
-            requestedQuantityMap.put(dto.productId(), dto.requestedStockQuantity());
-        }
 
-        // 재고 차감 시도
-        Boolean status;
-        try {
-            status = stockService.decreaseStocks(requestedQuantityMap);
-            if (status) {
-                // 재고 차감 성공 시
-                return ApiResponse.of(SuccessStatus._OK, new StockAdjustmentResponseDto(status, new ArrayList<UUID>(requestedQuantityMap.keySet()))); 
-            } else {
-                // 실패시
-                return ApiResponse.onFailure(
-                    ErrorStatus._CONFLICT.getCode(),
-                    ErrorStatus._CONFLICT.getMessage(),
-                    new StockAdjustmentResponseDto(false, new ArrayList<>(requestedQuantityMap.keySet()))
-                );
-            }
-        } catch (InsufficientStockException e) {
-            return ApiResponse.onFailure(
-                ErrorStatus._INSUFFICIENT_STOCK_QUANTITY.getCode() , 
-                ErrorStatus._INSUFFICIENT_STOCK_QUANTITY.getMessage(), 
-                new StockAdjustmentResponseDto(false, new ArrayList<UUID>(requestedQuantityMap.keySet()))
-            );
-        } catch (ObjectOptimisticLockingFailureException | StaleObjectStateException e) {
-            return ApiResponse.onFailure(
-                ErrorStatus._ADJUST_STOCK_FAILED.getCode() , 
-                ErrorStatus._ADJUST_STOCK_FAILED.getMessage(), 
-                new StockAdjustmentResponseDto(false, new ArrayList<UUID>(requestedQuantityMap.keySet()))
-            );
-        }
-    }
-
-    @PostMapping("/increase")
-    public ApiResponse<StockAdjustmentResponseDto> increaseStocks(
-        @RequestBody @Valid StockAdjustmentRequestDto stockAdjustmentRequestDto
-    ) {
-        Map<UUID, Integer> requestedQuantityMap = new HashMap<UUID, Integer>();
-        for (ProductStockAdjustmentRequestDto dto : stockAdjustmentRequestDto.products()) {
-            requestedQuantityMap.put(dto.productId(), dto.requestedStockQuantity());
-        }
-
-        Boolean status;
-        try {
-            // 재고 증가
-            status = stockService.increaseStocks(requestedQuantityMap);
-            if (status) {
-                // 재고 증가 성공 시
-                return ApiResponse.of(SuccessStatus._OK, new StockAdjustmentResponseDto(status, new ArrayList<UUID>(requestedQuantityMap.keySet()))); 
-            } else {
-                // 실패시
-                return ApiResponse.onFailure(
-                    ErrorStatus._CONFLICT.getCode(),
-                    ErrorStatus._CONFLICT.getMessage(),
-                    new StockAdjustmentResponseDto(false, new ArrayList<>(requestedQuantityMap.keySet()))
-                );
-            }
-        } catch (ObjectOptimisticLockingFailureException | StaleObjectStateException e) {
-            return ApiResponse.onFailure(
-                ErrorStatus._ADJUST_STOCK_FAILED.getCode() , 
-                ErrorStatus._ADJUST_STOCK_FAILED.getMessage(), 
-                new StockAdjustmentResponseDto(false, new ArrayList<UUID>(requestedQuantityMap.keySet()))
-            );
-        }
-    }
-    
 }

--- a/src/main/java/profect/group1/goormdotcom/stock/controller/internal/v1/StockInternalController.java
+++ b/src/main/java/profect/group1/goormdotcom/stock/controller/internal/v1/StockInternalController.java
@@ -1,13 +1,17 @@
 package profect.group1.goormdotcom.stock.controller.internal.v1;
 
+import org.hibernate.StaleObjectStateException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import profect.group1.goormdotcom.apiPayload.code.status.ErrorStatus;
 import profect.group1.goormdotcom.stock.controller.internal.v1.dto.ProductStockAdjustmentRequestDto;
 import profect.group1.goormdotcom.stock.controller.internal.v1.dto.StockAdjustmentRequestDto;
 import profect.group1.goormdotcom.stock.controller.internal.v1.dto.StockAdjustmentResponseDto;
+import profect.group1.goormdotcom.stock.domain.exception.InsufficientStockException;
 import profect.group1.goormdotcom.stock.service.StockService;
 import profect.group1.goormdotcom.apiPayload.ApiResponse;
 import profect.group1.goormdotcom.apiPayload.code.status.SuccessStatus;
@@ -28,32 +32,78 @@ public class StockInternalController implements StockInternalApiDocs {
 
     private final StockService stockService;
 
-    
+
     @PostMapping("/decrease")
     public ApiResponse<StockAdjustmentResponseDto> decreaseStocks(
-        @RequestBody @Valid StockAdjustmentRequestDto stockAdjustmentRequestDto
+            @RequestBody @Valid StockAdjustmentRequestDto stockAdjustmentRequestDto
     ) {
         Map<UUID, Integer> requestedQuantityMap = new HashMap<UUID, Integer>();
         for (ProductStockAdjustmentRequestDto dto : stockAdjustmentRequestDto.products()) {
             requestedQuantityMap.put(dto.productId(), dto.requestedStockQuantity());
         }
 
-        // TODO: 재시도 로직 필요
-        Boolean status = stockService.decreaseStocks(requestedQuantityMap);
-        return ApiResponse.of(SuccessStatus._OK, new StockAdjustmentResponseDto(status, new ArrayList<UUID>(requestedQuantityMap.keySet())));
+        // 재고 차감 시도
+        Boolean status;
+        try {
+            status = stockService.decreaseStocks(requestedQuantityMap);
+            if (status) {
+                // 재고 차감 성공 시
+                return ApiResponse.of(SuccessStatus._OK, new StockAdjustmentResponseDto(status, new ArrayList<UUID>(requestedQuantityMap.keySet())));
+            } else {
+                // 실패시
+                return ApiResponse.onFailure(
+                        ErrorStatus._CONFLICT.getCode(),
+                        ErrorStatus._CONFLICT.getMessage(),
+                        new StockAdjustmentResponseDto(false, new ArrayList<>(requestedQuantityMap.keySet()))
+                );
+            }
+        } catch (InsufficientStockException e) {
+            return ApiResponse.onFailure(
+                    ErrorStatus._INSUFFICIENT_STOCK_QUANTITY.getCode() ,
+                    ErrorStatus._INSUFFICIENT_STOCK_QUANTITY.getMessage(),
+                    new StockAdjustmentResponseDto(false, new ArrayList<UUID>(requestedQuantityMap.keySet()))
+            );
+        } catch (ObjectOptimisticLockingFailureException | StaleObjectStateException e) {
+            return ApiResponse.onFailure(
+                    ErrorStatus._ADJUST_STOCK_FAILED.getCode() ,
+                    ErrorStatus._ADJUST_STOCK_FAILED.getMessage(),
+                    new StockAdjustmentResponseDto(false, new ArrayList<UUID>(requestedQuantityMap.keySet()))
+            );
+        }
     }
 
     @PostMapping("/increase")
     public ApiResponse<StockAdjustmentResponseDto> increaseStocks(
-        @RequestBody @Valid StockAdjustmentRequestDto stockAdjustmentRequestDto
+            @RequestBody @Valid StockAdjustmentRequestDto stockAdjustmentRequestDto
     ) {
         Map<UUID, Integer> requestedQuantityMap = new HashMap<UUID, Integer>();
         for (ProductStockAdjustmentRequestDto dto : stockAdjustmentRequestDto.products()) {
             requestedQuantityMap.put(dto.productId(), dto.requestedStockQuantity());
         }
 
-        Boolean status = stockService.increaseStocks(requestedQuantityMap);
-        return ApiResponse.of(SuccessStatus._OK, new StockAdjustmentResponseDto(status, new ArrayList<UUID>(requestedQuantityMap.keySet())));
+        Boolean status;
+        try {
+            // 재고 증가
+            status = stockService.increaseStocks(requestedQuantityMap);
+            if (status) {
+                // 재고 증가 성공 시
+                return ApiResponse.of(SuccessStatus._OK, new StockAdjustmentResponseDto(status, new ArrayList<UUID>(requestedQuantityMap.keySet())));
+            } else {
+                // 실패시
+                return ApiResponse.onFailure(
+                        ErrorStatus._CONFLICT.getCode(),
+                        ErrorStatus._CONFLICT.getMessage(),
+                        new StockAdjustmentResponseDto(false, new ArrayList<>(requestedQuantityMap.keySet()))
+                );
+            }
+        } catch (ObjectOptimisticLockingFailureException | StaleObjectStateException e) {
+            return ApiResponse.onFailure(
+                    ErrorStatus._ADJUST_STOCK_FAILED.getCode() ,
+                    ErrorStatus._ADJUST_STOCK_FAILED.getMessage(),
+                    new StockAdjustmentResponseDto(false, new ArrayList<UUID>(requestedQuantityMap.keySet()))
+            );
+        }
     }
-    
+
+
 }

--- a/src/main/java/profect/group1/goormdotcom/stock/service/AdjustStockService.java
+++ b/src/main/java/profect/group1/goormdotcom/stock/service/AdjustStockService.java
@@ -1,5 +1,6 @@
 package profect.group1.goormdotcom.stock.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -8,6 +9,11 @@ import lombok.RequiredArgsConstructor;
 import profect.group1.goormdotcom.stock.repository.StockRepository;
 import profect.group1.goormdotcom.stock.repository.entity.StockEntity;
 
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
 @Getter
 @Service
 @RequiredArgsConstructor
@@ -16,14 +22,32 @@ public class AdjustStockService {
     private final StockRepository stockRepository;
 
     @Transactional
-    public void tryDecreaseQuantity(StockEntity entity, int requestedStockQuantity) {
-        entity.decreaseQuantity(requestedStockQuantity);
-        stockRepository.save(entity);
+    public void tryDecreaseStocks(Map<UUID, Integer> requestedQuantityMap) {
+        for (UUID productId: requestedQuantityMap.keySet()) {
+            Optional<StockEntity> stockEntity = stockRepository.findByProductId(productId);
+
+            if (stockEntity.isEmpty()) {
+                throw new IllegalArgumentException("Product not found");
+            }
+            StockEntity entity = stockEntity.get();
+            int requestedStockQuantity = requestedQuantityMap.get(productId);
+            entity.decreaseQuantity(requestedStockQuantity);
+            stockRepository.save(entity);
+        }
     }
 
     @Transactional
-    public void tryIncreaseQuantity(StockEntity entity, int requestedStockQuantity) {
-        entity.increaseQuantity(requestedStockQuantity);
-        stockRepository.save(entity);
+    public void tryIncreaseStocks(Map<UUID, Integer> requestedQuantityMap) {
+        for (UUID productId: requestedQuantityMap.keySet()) {
+            Optional<StockEntity> stockEntity = stockRepository.findByProductId(productId);
+
+            if (stockEntity.isEmpty()) {
+                throw new IllegalArgumentException("Product not found");
+            }
+            StockEntity entity = stockEntity.get();
+            int requestedStockQuantity = requestedQuantityMap.get(productId);
+            entity.increaseQuantity(requestedStockQuantity);
+            stockRepository.save(entity);
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#58 
## 📝 요약(Summary)

내외부 Controller 분리 및 낙관적 락 로직 수정

## 📝 리뷰 요청사항

- 트랜잭션 설계

## 💻 테스트 결과

- jmeter를 사용해서 100개의 재고에 100개의 동시 요청을 보냈고 최대 재시도 횟수를 넘기면서 실패하지 않았을 때, 100개 차감 확인했습니다.
